### PR TITLE
feat: add build step for server renderMode

### DIFF
--- a/examples/simple-server/mondo.config.ts
+++ b/examples/simple-server/mondo.config.ts
@@ -1,0 +1,7 @@
+export default {
+	root: '/src',
+	renderMode: 'server',
+	server: {
+		port: 8000,
+	},
+};

--- a/examples/simple-server/package.json
+++ b/examples/simple-server/package.json
@@ -5,11 +5,13 @@
     "type": "module",
     "scripts": {
         "dev": "mondo dev",
-        "build": "rm -rf ./build && mondo build"
+        "build": "rm -rf ./build && mondo build",
+        "start": "npm run build && mondo start"
     },
     "keywords": [],
     "author": "",
     "dependencies": {
-        "@mondo/mondo": "^0.0.1"
+        "@mondo/mondo": "^0.0.1",
+        "express": "^4.18.2"
     }
 }

--- a/examples/simple-server/package.json
+++ b/examples/simple-server/package.json
@@ -1,5 +1,5 @@
 {
-    "name": "simple-static",
+    "name": "simple-server",
     "version": "1.0.0",
     "description": "",
     "type": "module",

--- a/examples/simple-server/src/data/currentYear.ts
+++ b/examples/simple-server/src/data/currentYear.ts
@@ -1,0 +1,3 @@
+export default function () {
+	return new Date().getFullYear();
+}

--- a/examples/simple-server/src/pages/[page].ts
+++ b/examples/simple-server/src/pages/[page].ts
@@ -1,0 +1,36 @@
+const pages = [
+	{
+		slug: 'page-one',
+		title: 'Page One',
+	},
+	{
+		slug: 'pages/page-two',
+		title: 'Prerendered Page Two',
+	},
+];
+
+export async function createPage(ctx) {
+	// Matches the [page].ts
+	const slug = ctx.params.page;
+
+	const pageData = pages.find((page) => page.slug === slug);
+
+	if (!pageData) {
+		return;
+	}
+
+	return {
+		template: 'base.njk',
+		title: pageData?.title,
+		slug: pageData?.slug,
+		prerender: slug === 'pages/page-two',
+	};
+}
+
+// This function is only needed for SSG or if using pre-render in server mode
+export async function createPaths() {
+	return pages.map((pageData) => ({
+		// Return the [page] param for SSG
+		page: pageData.slug,
+	}));
+}

--- a/examples/simple-server/src/pages/index.ts
+++ b/examples/simple-server/src/pages/index.ts
@@ -1,0 +1,7 @@
+export async function createPage() {
+	return {
+		title: 'Prerendered Homepage',
+		template: 'base.njk',
+		prerender: true,
+	};
+}

--- a/examples/simple-server/src/pages/projects/project-one.ts
+++ b/examples/simple-server/src/pages/projects/project-one.ts
@@ -1,0 +1,6 @@
+export async function createPage() {
+	return {
+		title: 'Project One',
+		template: 'base.njk',
+	};
+}

--- a/examples/simple-server/src/views/base.njk
+++ b/examples/simple-server/src/views/base.njk
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>Page</title>
+    </head>
+    <body>
+   this is the {{title}}
+   the current year is {{currentYear}}
+    </body>
+</html>

--- a/examples/simple-server/tsconfig.json
+++ b/examples/simple-server/tsconfig.json
@@ -1,0 +1,11 @@
+{
+    "compilerOptions": {
+        "baseUrl": ".",
+        "module": "NodeNext",
+        "moduleResolution": "NodeNext",
+        "resolveJsonModule": true,
+        "esModuleInterop": true,
+        "strictNullChecks": true,
+    },
+    "exclude": [".vscode"],
+}

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
         "mondo:dev": "pnpm -F @mondo/mondo dev",
         "mondo:test": "pnpm -F @mondo/mondo test",
         "demo:dev": "pnpm mondo:build && pnpm -F simple-static dev",
-        "demo:build": "pnpm mondo:build && pnpm -F simple-static build"
+        "demo:build": "pnpm mondo:build && pnpm -F simple-static build",
+        "demo-server:build": "pnpm mondo:build && pnpm -F simple-server build"
     },
     "engines": {
         "node": ">=16.12.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
         "mondo:test": "pnpm -F @mondo/mondo test",
         "demo:dev": "pnpm mondo:build && pnpm -F simple-static dev",
         "demo:build": "pnpm mondo:build && pnpm -F simple-static build",
-        "demo-server:build": "pnpm mondo:build && pnpm -F simple-server build"
+        "demo-server:build": "pnpm mondo:build && pnpm -F simple-server build",
+        "demo-server:start": "pnpm mondo:build && pnpm -F simple-server start"
     },
     "engines": {
         "node": ">=16.12.0",

--- a/packages/mondo/src/builder/app.ts
+++ b/packages/mondo/src/builder/app.ts
@@ -11,13 +11,17 @@ const { port, templateEngine } = server;
 
 const app: Express = express();
 
-/* Make sure static routes and dynamic routes with more depth
-	are prioritized */
+/**
+ *  Make sure static routes and dynamic routes with more depth
+ * are prioritized
+ */
 const mergedRoutes = generateMergedRoutes(path.join(buildDirectory, 'pages'));
 
 app.use('/public', express.static(path.join(buildDirectory, 'public')));
 
 app.use('/', express.static(path.join(buildDirectory, 'html')));
+
+//TODO: Implement global data
 
 const engine = new TemplateEngine({
 	engine: templateEngine,

--- a/packages/mondo/src/builder/app.ts
+++ b/packages/mondo/src/builder/app.ts
@@ -1,0 +1,78 @@
+/** Production server file */
+import express, { Express, Request, Response, NextFunction } from 'express';
+import path from 'path';
+//@ts-ignore
+import CONFIG_DATA from './config.json' assert { type: 'json' };
+//@ts-ignore
+import { TemplateEngine, generateMergedRoutes, mergeDeep } from '@mondo/mondo';
+
+const { server, buildDirectory, viewsDirectory } = CONFIG_DATA;
+const { port, templateEngine } = server;
+
+const app: Express = express();
+
+/* Make sure static routes and dynamic routes with more depth
+	are prioritized */
+const mergedRoutes = generateMergedRoutes(path.join(buildDirectory, 'pages'));
+
+app.use('/public', express.static(path.join(buildDirectory, 'public')));
+
+app.use('/', express.static(path.join(buildDirectory, 'html')));
+
+const engine = new TemplateEngine({
+	engine: templateEngine,
+	viewsDirectory,
+	app,
+});
+
+for (const routeFile of mergedRoutes) {
+	const route = await import(routeFile);
+
+	const routeName = routeFile
+		.replace(`${buildDirectory}/pages`, '')
+		.replace('[', ':')
+		.replace(']', '')
+		.replace('index', '')
+		.replace('.js', '');
+
+	/**
+	 *  Handles nested slugs like /pages/nested-page/test
+	 * also make sure the '/' doesn't act like a catch-all
+	 * for every root-level route.
+	 * */
+	const getPath = routeName === '/' ? routeName : `${routeName}(*)?`;
+
+	app.get(
+		getPath,
+		async (req: Request, res: Response, next: NextFunction) => {
+			const pageData = await route.createPage(req);
+
+			if (pageData) {
+				if (pageData) {
+					const outputHTML = await engine._renderTemplate(
+						pageData?.template,
+						/** Pass a combined object of page and global data */
+						mergeDeep(pageData, app.locals)
+					);
+
+					res.setHeader('Content-Type', 'text/html');
+					res.send(outputHTML);
+				} else {
+					/* Send to 404 if there is no data sent to template */
+					res.status(404);
+					next();
+				}
+			}
+		}
+	);
+}
+
+/* 404 catch-all */
+app.get('*', (req: Request, res: Response, next: NextFunction) => {
+	res.status(404);
+	res.send('Page not found');
+});
+
+app.listen(port, () =>
+	console.log(`Server started on http://localhost:${port}`)
+);

--- a/packages/mondo/src/builder/app.ts
+++ b/packages/mondo/src/builder/app.ts
@@ -1,5 +1,6 @@
 /** Production server file */
 import express, { Express, Request, Response, NextFunction } from 'express';
+import fs from 'fs';
 import path from 'path';
 //@ts-ignore
 import CONFIG_DATA from './config.json' assert { type: 'json' };
@@ -17,17 +18,45 @@ const app: Express = express();
  */
 const mergedRoutes = generateMergedRoutes(path.join(buildDirectory, 'pages'));
 
-app.use('/public', express.static(path.join(buildDirectory, 'public')));
+/** Handle global data middleware  */
+const globalDataDirectory = path.join(buildDirectory, 'data');
+const globalDataDirectoryExists = fs.existsSync(globalDataDirectory);
 
-app.use('/', express.static(path.join(buildDirectory, 'html')));
+if (globalDataDirectoryExists) {
+	const globalDataFiles = fs.readdirSync(globalDataDirectory);
 
-//TODO: Implement global data
+	(async function () {
+		for await (const dataFile of globalDataFiles) {
+			/* Read each data file and get it's default exported function */
+			const dataFileFunctions = await import(
+				path.join(globalDataDirectory, dataFile)
+			);
+			const dataFileContents = dataFileFunctions.default;
+
+			/* Get the name of the file and the return value
+			of the callback */
+			const dataBasename = dataFile
+				.replace(globalDataDirectory, '')
+				.replace('.js', '');
+
+			const data = await dataFileContents();
+
+			/* Set the value of each data file to a local global
+			 * variable in the app */
+			app.locals[dataBasename] = data;
+		}
+	})();
+}
 
 const engine = new TemplateEngine({
 	engine: templateEngine,
 	viewsDirectory,
 	app,
 });
+
+app.use('/public', express.static(path.join(buildDirectory, 'public')));
+
+app.use('/', express.static(path.join(buildDirectory, 'html')));
 
 for (const routeFile of mergedRoutes) {
 	const route = await import(routeFile);

--- a/packages/mondo/src/builder/server.ts
+++ b/packages/mondo/src/builder/server.ts
@@ -6,6 +6,7 @@ import { generateMergedRoutes, walkSync } from '@/utils/router.js';
 import { compileAndRunTS, tsCompile } from '@/utils/compileAndRunTs.js';
 import { logBlue } from '@/utils/logger.js';
 import { buildStaticSite } from '@/builder/static.js';
+import { getSiteInternals } from '@/utils/internals.js';
 
 export async function generateServerBundle(options: ConfigOptions) {
 	/** Generate as compiled manifest of all route data */
@@ -18,10 +19,11 @@ export async function generateServerBundle(options: ConfigOptions) {
 	logBlue(`Compiling Mondo config file...`);
 	/** Compile config file and output to build */
 	const configPath = path.join(process.cwd(), 'mondo.config.ts');
-	const compiledConfigFile = await compileAndRunTS(configPath);
+	const importedConfigFile = await compileAndRunTS(configPath);
+	const CONFIG_FILE_DATA = getSiteInternals(importedConfigFile);
 	outputFile(
 		`${buildDirectory}/config.json`,
-		JSON.stringify(compiledConfigFile.default)
+		JSON.stringify(CONFIG_FILE_DATA)
 	);
 
 	logBlue(`Building server route files...`);

--- a/packages/mondo/src/builder/server.ts
+++ b/packages/mondo/src/builder/server.ts
@@ -1,0 +1,79 @@
+import { ConfigOptions } from '@mondo/mondo';
+import fs from 'fs';
+import path from 'path';
+import { outputFile } from '@/utils/files.js';
+import { generateMergedRoutes, walkSync } from '@/utils/router.js';
+import { compileAndRunTS, tsCompile } from '@/utils/compileAndRunTs.js';
+import { logBlue } from '@/utils/logger.js';
+import { buildStaticSite } from '@/builder/static.js';
+
+export async function generateServerBundle(options: ConfigOptions) {
+	/** Generate as compiled manifest of all route data */
+	const pagesDirectory = options.pagesDirectory as string;
+	const buildDirectory = options.buildDirectory as string;
+	const globalDataDirectory = options.globalDataDirectory as string;
+
+	const mergedRoutes = generateMergedRoutes(pagesDirectory);
+
+	/** Compile config file and output to build */
+	logBlue(`Compiling Mondo config file...`);
+	const configPath = path.join(process.cwd(), 'mondo.config.ts');
+	const compiledConfigFile = await compileAndRunTS(configPath);
+	outputFile(
+		`${buildDirectory}/config.json`,
+		JSON.stringify(compiledConfigFile.default)
+	);
+
+	logBlue(`Building server route files...`);
+	/** Convert all route files to JS and output to the build directory */
+	for await (const routeFile of mergedRoutes) {
+		/** Compile the route file contents to JS */
+		const routeFileContents = fs.readFileSync(routeFile, {
+			encoding: 'utf-8',
+		});
+		const compiledRoute = await tsCompile(routeFileContents);
+
+		/**
+		 * Create a route output path to the build directory with
+		 * a compiled '.js' file extension
+		 */
+		const routePath = routeFile
+			.replace(pagesDirectory, `${buildDirectory}/pages`)
+			.replace('.ts', '.js');
+
+		outputFile(routePath, compiledRoute);
+	}
+
+	const globalDataFiles = walkSync(globalDataDirectory);
+
+	logBlue(`Building global data files...`);
+	/** Convert all global data files to JS and output to the build directory */
+	for await (const globalDataFile of globalDataFiles) {
+		/** Compile the route file contents to JS */
+		const dataFileContents = fs.readFileSync(globalDataFile, {
+			encoding: 'utf-8',
+		});
+		const compiledDataFile = await tsCompile(dataFileContents);
+
+		/* Create a route output path to the build directory with
+		 * a compiled '.js' file extension
+		 */
+		const routePath = globalDataFile
+			.replace(globalDataDirectory, `${buildDirectory}/data`)
+			.replace('.ts', '.js');
+
+		outputFile(routePath, compiledDataFile);
+	}
+
+	/**
+	 *  Pre-prendered HTML files will be built and live in
+	 * the 'build/html' directory.
+	 */
+	options['buildDirectory'] = path.join(
+		options['buildDirectory'] as string,
+		'html'
+	);
+
+	logBlue(`Building pre-rendered server routes...`);
+	await buildStaticSite(options);
+}

--- a/packages/mondo/src/builder/server.ts
+++ b/packages/mondo/src/builder/server.ts
@@ -15,8 +15,8 @@ export async function generateServerBundle(options: ConfigOptions) {
 
 	const mergedRoutes = generateMergedRoutes(pagesDirectory);
 
-	/** Compile config file and output to build */
 	logBlue(`Compiling Mondo config file...`);
+	/** Compile config file and output to build */
 	const configPath = path.join(process.cwd(), 'mondo.config.ts');
 	const compiledConfigFile = await compileAndRunTS(configPath);
 	outputFile(

--- a/packages/mondo/src/builder/server.ts
+++ b/packages/mondo/src/builder/server.ts
@@ -16,8 +16,9 @@ export async function generateServerBundle(options: ConfigOptions) {
 
 	const mergedRoutes = generateMergedRoutes(pagesDirectory);
 
-	logBlue(`Compiling Mondo config file...`);
 	/** Compile config file and output to build */
+	logBlue(`Compiling Mondo config file...`);
+
 	const configPath = path.join(process.cwd(), 'mondo.config.ts');
 	const importedConfigFile = await compileAndRunTS(configPath);
 	const CONFIG_FILE_DATA = getSiteInternals(importedConfigFile);
@@ -26,8 +27,9 @@ export async function generateServerBundle(options: ConfigOptions) {
 		JSON.stringify(CONFIG_FILE_DATA)
 	);
 
-	logBlue(`Building server route files...`);
 	/** Convert all route files to JS and output to the build directory */
+	logBlue(`Building server route files...`);
+
 	for await (const routeFile of mergedRoutes) {
 		/** Compile the route file contents to JS */
 		const routeFileContents = fs.readFileSync(routeFile, {
@@ -48,8 +50,9 @@ export async function generateServerBundle(options: ConfigOptions) {
 
 	const globalDataFiles = walkSync(globalDataDirectory);
 
-	logBlue(`Building global data files...`);
 	/** Convert all global data files to JS and output to the build directory */
+	logBlue(`Building global data files...`);
+
 	for await (const globalDataFile of globalDataFiles) {
 		/** Compile the route file contents to JS */
 		const dataFileContents = fs.readFileSync(globalDataFile, {
@@ -71,11 +74,27 @@ export async function generateServerBundle(options: ConfigOptions) {
 	 *  Pre-prendered HTML files will be built and live in
 	 * the 'build/html' directory.
 	 */
+
+	logBlue(`Building pre-rendered server routes...`);
+
 	options['buildDirectory'] = path.join(
 		options['buildDirectory'] as string,
 		'html'
 	);
 
-	logBlue(`Building pre-rendered server routes...`);
 	await buildStaticSite(options);
+
+	/** Copy compiled app.js file to the build folder */
+	logBlue(`Generating server file...`);
+	const builtServerFilePath = path.join(
+		process.cwd(),
+		'node_modules/@mondo/mondo/dist/builder/app.js'
+	);
+	const compiledServerContents = fs.readFileSync(builtServerFilePath, {
+		encoding: 'utf-8',
+	});
+
+	const compiledServerPath = path.join(buildDirectory, 'app.js');
+
+	outputFile(compiledServerPath, compiledServerContents);
 }

--- a/packages/mondo/src/builder/static.ts
+++ b/packages/mondo/src/builder/static.ts
@@ -10,7 +10,7 @@ import fs from 'fs';
 /**
  * Gets all the global data and creates a single object that can be used in the templates.
  * It handles the generation of static HTML files for the 'ssg' render mode and 'server' routes
- * that are set to be prerendered.
+ * that are set to be pre-rendered.
  *
  * @param globalDataDirectory Path to the globalDataDirectory set in config. Defaults to 'src/data'
  * @returns An object of global data values to send to the template
@@ -78,9 +78,6 @@ export async function buildStaticSite(options: ConfigOptions) {
 
 	const globalData = await getStaticGlobalData(globalDataDirectory);
 
-	// TODO: figure out how to implement global data files
-	// it can probably be passed in engine._renderTemplate as part
-	// of the data e.g. {...globalData, createdPage}
 	for await (const routeFile of mergedRoutes) {
 		const route = await resolveRoute({ routeFile, pagesDirectory });
 		const { data, routeName } = route;

--- a/packages/mondo/src/builder/static.ts
+++ b/packages/mondo/src/builder/static.ts
@@ -6,6 +6,7 @@ import { TemplateEngine } from '@/utils/templates.js';
 import { compileAndRunTS } from '@/utils/compileAndRunTs.js';
 import path from 'path';
 import fs from 'fs';
+import { mergeDeep } from '@/utils/helpers.js';
 
 /**
  * Gets all the global data and creates a single object that can be used in the templates.
@@ -149,7 +150,7 @@ export async function buildStaticSite(options: ConfigOptions) {
 					const compiledDynamicRouteHTML =
 						await engine._renderTemplate(
 							createdDynamicRoute.template,
-							{ ...globalData, ...createdDynamicRoute },
+							mergeDeep(globalData, createdDynamicRoute),
 							'build'
 						);
 
@@ -168,7 +169,7 @@ export async function buildStaticSite(options: ConfigOptions) {
 				/**  Get the generated HTML and build path */
 				const compiledStaticRouteHTML = await engine._renderTemplate(
 					createdPage.template,
-					{ ...globalData, ...createdPage },
+					mergeDeep(globalData, createdPage),
 					'build'
 				);
 				const staticRouteBuildPath = path.join(

--- a/packages/mondo/src/cli.ts
+++ b/packages/mondo/src/cli.ts
@@ -8,6 +8,7 @@ import { compileAndRunTS } from '@/utils/compileAndRunTs.js';
 import bs from 'browser-sync';
 import { getSiteInternals } from '@/utils/internals.js';
 import { buildStaticSite } from '@/builder/static.js';
+import { generateServerBundle } from './builder/server.js';
 
 const SITE_ROOT = process.cwd();
 
@@ -91,20 +92,10 @@ program
 		switch (renderMode) {
 			case 'server':
 				logBlue(
-					`The renderMode has been set to 'server'. Generating the pre-rendered server files...`
+					`The renderMode has been set to 'server'. Generating server build...`
 				);
 
-				/**
-				 *  Pre-prendered HTML files will be built and live in
-				 * the 'build/html' directory.
-				 */
-				CONFIG_FILE_DATA['buildDirectory'] = path.join(
-					CONFIG_FILE_DATA['buildDirectory'] as string,
-					'html'
-				);
-
-				/** Generate HTML files for pre-rendered routes  */
-				buildStaticSite(CONFIG_FILE_DATA);
+				await generateServerBundle(CONFIG_FILE_DATA);
 				break;
 			default:
 				logBlue(

--- a/packages/mondo/src/cli.ts
+++ b/packages/mondo/src/cli.ts
@@ -91,10 +91,21 @@ program
 		switch (renderMode) {
 			case 'server':
 				logBlue(
-					`The renderMode has been set to 'server'. Generating the server files...`
+					`The renderMode has been set to 'server'. Generating the pre-rendered server files...`
 				);
+
+				/**
+				 *  Pre-prendered HTML files will be built and live in
+				 * the 'build/html' directory.
+				 */
+				CONFIG_FILE_DATA['buildDirectory'] = path.join(
+					CONFIG_FILE_DATA['buildDirectory'] as string,
+					'html'
+				);
+
+				/** Generate HTML files for pre-rendered routes  */
+				buildStaticSite(CONFIG_FILE_DATA);
 				break;
-			// TODO: Implement server output
 			default:
 				logBlue(
 					`The renderMode has been set to 'ssg'. Generating the static build...`

--- a/packages/mondo/src/cli.ts
+++ b/packages/mondo/src/cli.ts
@@ -105,4 +105,25 @@ program
 		}
 	});
 
+program
+	.command('start')
+	.description('Start Mondo production server')
+	.action(() => {
+		const serverProcess = exec('node build/app.js');
+		/**
+		 * Log server processes fon updates
+		 */
+		serverProcess.stdout?.on('data', (data) => {
+			logBlue(`[Server Process]: ${data.toString()}`);
+		});
+
+		serverProcess.stderr?.on('data', (data) => {
+			logBlue(`[Server Error]: ${data.toString()}`);
+		});
+
+		serverProcess.on('exit', (code) => {
+			logBlue(`[Server Exit]: ${code?.toString()}`);
+		});
+	});
+
 program.parse();

--- a/packages/mondo/src/core.ts
+++ b/packages/mondo/src/core.ts
@@ -1,7 +1,13 @@
+import { TemplateEngine } from '@/utils/templates.js';
+import { generateMergedRoutes } from '@/utils/router.js';
 import { logGreen, logYellow, logRed } from '@/utils/logger.js';
+import { mergeDeep } from '@/utils/helpers.js';
 import { CreatePageContext, CreatePage, ConfigOptions } from '@mondo/mondo';
 
 export {
+	generateMergedRoutes,
+	TemplateEngine,
+	mergeDeep,
 	logGreen,
 	logYellow,
 	logRed,

--- a/packages/mondo/src/dev/app.ts
+++ b/packages/mondo/src/dev/app.ts
@@ -9,6 +9,7 @@ import {
 	configureAppInternals,
 	initialzeGlobalDataMiddleware,
 } from '@/utils/server.js';
+import { mergeDeep } from '@/utils/helpers.js';
 
 /**
  * Initializes and runs an Express app for the dev server
@@ -77,7 +78,7 @@ for (const route of mergedRoutes) {
 				const outputHTML = await engine._renderTemplate(
 					pageData?.template,
 					/** Pass a combined object of page and global data */
-					{ ...pageData, ...app.locals }
+					mergeDeep(pageData, app.locals)
 				);
 
 				res.setHeader('Content-Type', 'text/html');

--- a/packages/mondo/src/dev/app.ts
+++ b/packages/mondo/src/dev/app.ts
@@ -1,5 +1,4 @@
 import path from 'path';
-import { ConfigOptions } from '@mondo/mondo';
 import express, { Express, NextFunction, Request, Response } from 'express';
 import { logGreen, logRed } from '@/utils/logger.js';
 import { generateMergedRoutes, resolveRoute } from '@/utils/router.js';
@@ -10,10 +9,6 @@ import {
 	configureAppInternals,
 	initialzeGlobalDataMiddleware,
 } from '@/utils/server.js';
-
-export interface RunDevServerOptions {
-	internals: ConfigOptions;
-}
 
 /**
  * Initializes and runs an Express app for the dev server

--- a/packages/mondo/src/utils/helpers.ts
+++ b/packages/mondo/src/utils/helpers.ts
@@ -1,0 +1,31 @@
+/**
+ * Simple object check.
+ * @param item
+ * @returns {boolean}
+ */
+export function isObject(item) {
+	return item && typeof item === 'object' && !Array.isArray(item);
+}
+
+/**
+ * Deep merge two objects.
+ * @param target
+ * @param ...sources
+ */
+export function mergeDeep(target, ...sources) {
+	if (!sources.length) return target;
+	const source = sources.shift();
+
+	if (isObject(target) && isObject(source)) {
+		for (const key in source) {
+			if (isObject(source[key])) {
+				if (!target[key]) Object.assign(target, { [key]: {} });
+				mergeDeep(target[key], source[key]);
+			} else {
+				Object.assign(target, { [key]: source[key] });
+			}
+		}
+	}
+
+	return mergeDeep(target, ...sources);
+}

--- a/packages/mondo/src/utils/internals.ts
+++ b/packages/mondo/src/utils/internals.ts
@@ -1,5 +1,6 @@
 import { ConfigOptions, DefaultDynamicallyImportedFile } from '@mondo/mondo';
 import path from 'path';
+import { mergeDeep } from '@/utils/helpers.js';
 
 const ROOT_PATH = path.join(process.cwd(), 'src');
 
@@ -35,7 +36,10 @@ export function getSiteInternals(
 		/** Merge the config file content with the fallback and make sure
 		 * that the config file overrides the default.
 		 */
-		parsedConfiguration = { ...DEFAULT_MONDO_CONFIGURATION, ...configData };
+		parsedConfiguration = mergeDeep(
+			DEFAULT_MONDO_CONFIGURATION,
+			configData
+		);
 	}
 
 	return parsedConfiguration;

--- a/packages/mondo/tsconfig.build.json
+++ b/packages/mondo/tsconfig.build.json
@@ -19,7 +19,8 @@
         "./src/cli.ts",
         "./src/dev/app.ts",
         "./src/builder/server.ts",
-        "./src/builder/static.ts"
+        "./src/builder/static.ts",
+        "./src/builder/app.ts",
     ],
     "exclude": [],
     "watchOptions": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,6 +73,15 @@ importers:
         specifier: ^5.1.6
         version: 5.1.6
 
+  examples/simple-server:
+    dependencies:
+      '@mondo/mondo':
+        specifier: ^0.0.1
+        version: link:../../packages/mondo
+      express:
+        specifier: ^4.18.2
+        version: 4.18.2
+
   examples/simple-static:
     dependencies:
       '@mondo/mondo':


### PR DESCRIPTION
Generate bundle when using `server` render mode.

- Build pre-rendered pages to `build/html`
- Build global data files and write to `build/data`
- Build server file to build directory
- Compile and copy config file to build directory
- Add `mondo start` command to cli